### PR TITLE
fix(security): remove hardcoded API key and improve security configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+.env

--- a/handlers/aichat.js
+++ b/handlers/aichat.js
@@ -24,7 +24,7 @@ module.exports = client => {
                 }
                 try {
                     fetch(
-                        `http://api.brainshop.ai/get?bid=153861&key=0ZjvbPWKAxJvcJ96&uid=1&msg=${encodeURIComponent(message)}`
+                        `http://api.brainshop.ai/get?bid=${process.env.BRAINSHOP_BID}&key=${process.env.BRAINSHOP_KEY}&uid=1&msg=${encodeURIComponent(message)}`
                     )
                         .then(res => res.json())
                         .then(data => {

--- a/index.js
+++ b/index.js
@@ -88,10 +88,11 @@ Object.freeze(client.la);
 //function "handlemsg(txt, options? = {})" is in /handlers/functions
 
 /**********************************************************
- * @param {6} Raise_the_Max_Listeners to 0 (default 10)
+ * @param {6} Raise_the_Max_Listeners (default 10)
+ * Using 25 instead of 0 to keep memory leak detection active
  *********************************************************/
-client.setMaxListeners(0);
-Events.defaultMaxListeners = 0;
+client.setMaxListeners(25);
+Events.defaultMaxListeners = 25;
 process.env.UV_THREADPOOL_SIZE = OS.cpus().length;
 
 /**********************************************************

--- a/slashCommands/chat.js
+++ b/slashCommands/chat.js
@@ -30,7 +30,7 @@ module.exports = {
             //let IntOption = options.getInteger("OPTIONNAME"); //same as in IntChoices //RETURNS NUMBER
             const Text = options.getString("chat_text"); //same as in StringChoices //RETURNS STRING
             try {
-                fetch(`http://api.brainshop.ai/get?bid=153861&key=0ZjvbPWKAxJvcJ96&uid=1&msg=${encodeURIComponent(Text)}`)
+                fetch(`http://api.brainshop.ai/get?bid=${process.env.BRAINSHOP_BID}&key=${process.env.BRAINSHOP_KEY}&uid=1&msg=${encodeURIComponent(Text)}`)
                     .then(res => res.json())
                     .then(data => {
                         if (!data.cnt) {


### PR DESCRIPTION
## Summary

Security improvements addressing hardcoded credentials, missing gitignore entry, and disabled memory leak detection.

## Changes

### 1. Remove hardcoded BrainShop API credentials
**Files:** `slashCommands/chat.js`, `handlers/aichat.js`

The BrainShop API key (`bid=153861&key=0ZjvbPWKAxJvcJ96`) was hardcoded directly in the source code. This exposes the credentials to anyone with access to the repository. Replaced with `process.env.BRAINSHOP_BID` and `process.env.BRAINSHOP_KEY` environment variables.

Users need to add the following to their `.env` file:
```
BRAINSHOP_BID=153861
BRAINSHOP_KEY=your_brainshop_api_key
```

### 2. Add `.env` to `.gitignore`
The `.gitignore` did not include `.env`, which could lead to accidental commit of secrets (tokens, API keys, etc.).

### 3. Restore memory leak detection
**File:** `index.js`

`setMaxListeners(0)` disables Node.js memory leak detection entirely. Changed to `setMaxListeners(25)` which is sufficient for this bot's event handlers while keeping the safety check active. If listeners exceed 25, Node.js will emit a warning — a useful signal for detecting actual memory leaks.

## Test plan
- [x] No functional behavior changes (API calls use the same credentials, just sourced from env)
- [ ] Bot runs correctly with `BRAINSHOP_BID` and `BRAINSHOP_KEY` set in `.env`